### PR TITLE
Container was not starting.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,13 +29,19 @@ readonly FCGISOCKET="/var/run/fcgiwrap.socket"
 main() {
   mkdir -p $GIT_PROJECT_ROOT
 
-  initialize_initial_repositories
+  # Checks if $GIT_INITIAL_ROOT has files
+  if [[ $(ls -A ${GIT_INITIAL_ROOT}) ]]; then
+    initialize_initial_repositories
+  fi
   initialize_services
 }
 
 initialize_services() {
-  chown -R git:git $GIT_PROJECT_ROOT
-  chmod -R 775 $GIT_PROJECT_ROOT
+  # Check permissions on $GIT_PROJECT_ROOT
+  if [[ ! $(stat -c %A ${GIT_PROJECT_ROOT}) -eq "drwxr-xr-x" ]]; then
+    chown -R giti:git $GIT_PROJECT_ROOT
+    chmod -R 775 $GIT_PROJECT_ROOT
+  fi
 
   /usr/bin/spawn-fcgi \
     -s $FCGISOCKET \


### PR DESCRIPTION
Turns out in a prior commit the startup sequence was refactored, removing the case statement that checked for parameters. Instead of putting that back, I added a conditional to check if there is anything in $GIT_INITIAL_REPO and run the init.

I also added an additional conditional to check file permissions before running chmod/chown, as this caused no small amount of permission denied errors when $GIT_PROJECT_ROOT is a volume with existing repos.

A make test runs clean here:
```
$ make test
./test.sh
+ trap cleanup EXIT
+ main
+ init_docker_container
+ docker-compose -f ./example/docker-compose.yml up -d
Creating network "example_default" with the default driver
Creating example_gitserver_1 ...
Creating example_gitserver_1 ... done
+ sleep 3
+ assert_can_clone
+ git clone http://localhost:8080/myrepo.git
Cloning into 'myrepo'...
remote: warning: unable to access '/root/.config/git/attributes': Permission denied
remote: Counting objects: 3, done.
remote: Total 3 (delta 0), reused 0 (delta 0)
Unpacking objects: 100% (3/3), done.
+ [[ -f myrepo/myfile.txt ]]
+ echo 'OK!'
OK!
+ cleanup
+ local exit_code=0
+ echo 'Exited with [0]'
Exited with [0]
+ docker-compose -f ./example/docker-compose.yml stop
Stopping example_gitserver_1 ... done
+ rm -rf ./myrepo
```