### PR TITLE
Cant clone Repository with the latest Nginx  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.13.5-alpine
 
 RUN set -x && \
   apk --update upgrade                                  &&  \


### PR DESCRIPTION
Cant pull Git Repos with the latest Nginx Docker Image

https://travis-ci.org/nolte/gitserver-http/builds/347485244

`
Cloning into 'myrepo'...
remote: 403 Forbidden
fatal: unable to access 'http://localhost:8080/myrepo.git/': The requested URL returned error: 403
`

QuickFix: change `nginx:latest` to `nginx:1.13.5-alpine`