### PR TITLE
Add client_max_body_size to nginx.conf

### DIFF
--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -12,6 +12,7 @@ http {
 	tcp_nodelay           on;
 	keepalive_timeout     65;
 	types_hash_max_size   2048;
+	client_max_body_size  0;
 
 	include               /etc/nginx/mime.types;
 	default_type          application/octet-stream;


### PR DESCRIPTION
I have added client_max_body_size to nginx.conf to fix 413 error of nginx (when push large file).